### PR TITLE
Fix URLHandler for npm git repos with nonhttps format

### DIFF
--- a/src/metrics/RampUp.ts
+++ b/src/metrics/RampUp.ts
@@ -107,7 +107,7 @@ export class RampUp extends Metric {
 
             // ensure that the total code size is not 0 to avoid division by 0
             if(total_documentation_size === 0) {
-                this.score = -1;
+                this.score = 0;
             }
             else {
                 const ramp_up_ratio = (total_documentation_size / total_code_size);

--- a/src/test/RampUp.test.ts
+++ b/src/test/RampUp.test.ts
@@ -60,7 +60,7 @@ describe('RampUp', () => {
         (axios.get as jest.Mock).mockResolvedValueOnce(mockResponse);
         await rampUp.calculateScore();
 
-        expect(rampUp.getScore()).toBe(-1);
+        expect(rampUp.getScore()).toBe(0);
     });
 
     it('should properly calculate score when no programming files', async () => {

--- a/src/test/RampUp.test.ts
+++ b/src/test/RampUp.test.ts
@@ -60,7 +60,7 @@ describe('RampUp', () => {
         (axios.get as jest.Mock).mockResolvedValueOnce(mockResponse);
         await rampUp.calculateScore();
 
-        expect(rampUp.getScore()).toBe(0);
+        expect(rampUp.getScore()).toBe(-1);
     });
 
     it('should properly calculate score when no programming files', async () => {

--- a/src/test/URLHandler.test.ts
+++ b/src/test/URLHandler.test.ts
@@ -1,3 +1,4 @@
+import { Logger } from '../logUtils';
 import { URLHandler } from '../utils/URLHandler';
 import axios from 'axios';
 
@@ -121,13 +122,13 @@ describe('URLHandler', () => {
     describe('getGithubURLFromNpmURL', () => {
         beforeEach(() => {
             (axios.get as jest.Mock).mockImplementation(url => {
-                if (url === 'https://www.npmjs.com/package/express') {
+                if (url === 'https://registry.npmjs.org/express') {
                     return Promise.resolve({
-                        data: '<html><body><a href="https://github.com/expressjs/express">GitHub</a></body></html>'
+                        data: {repository: { type: 'git', url: 'git+https://github.com/expressjs/express.git' }}
                     });
-                } else if (url === 'https://www.npmjs.com/package/nonexistent') {
+                } else if (url === 'https://registry.npmjs.org/nonexistent') {
                     return Promise.resolve({
-                        data: '<html><body>No GitHub link here</body></html>'
+                        data: {repository: {}}
                     });
                 }
                 return Promise.reject(new Error('404 Not Found'));

--- a/src/test/run.test.ts
+++ b/src/test/run.test.ts
@@ -66,7 +66,7 @@ describe('Test run.ts main', () => {
         catch (error: any) {
           expect(null).not.toBeFalsy() // fail() shouldn't reach this line
         }      
-      });
+      }, 10000);
   });
   
 });

--- a/src/test/urlCommand.test.ts
+++ b/src/test/urlCommand.test.ts
@@ -30,7 +30,7 @@ describe('urlCommand', () => {
             expect(consoleSpy).toHaveBeenCalledWith(expect.stringMatching(
                 /{"URL":"(https:\/\/www\.npmjs\.com\/package\/[a-zA-Z0-9\-]+|https:\/\/github\.com\/[a-zA-Z0-9\-]+\/[a-zA-Z0-9\-]+)",\s*"NetScore":\d+(\.\d+)?,\s*"NetScore_Latency":\d+(\.\d+)?,\s*"RampUp":\d+(\.\d+)?,\s*"RampUp_Latency":\d+(\.\d+)?,\s*"Correctness":\d+(\.\d+)?,\s*"Correctness_Latency":\d+(\.\d+)?,\s*"BusFactor":-?\d+(\.\d+)?,\s*"BusFactor_Latency":-?\d+(\.\d+)?,\s*"ResponsiveMaintainer":\d+(\.\d+)?,\s*"ResponsiveMaintainer_Latency":\d+(\.\d+)?,\s*"License":\d+(\.\d+)?,\s*"License_Latency":\d+(\.\d+)?}/
             ));
-        });
+        }, 10000);
     });
     describe('URL Command No File', () => {
         afterEach(() => {


### PR DESCRIPTION
Example: https://www.npmjs.com/package/socket.io

With old method: https:github.com/socketio/socket.io  --> did not catch the ".io" i.e. https:github.com/socketio/socket

Updated method to get from package.json file instead (https://registry.npmjs.org/packageName)